### PR TITLE
Add conditional to XHProf install.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,8 @@
 - name: Get XHProf info if installed.
   command: "pecl info xhprof"
   register: "xhprof_info"
+  changed_when: "not '0.9.4' in xhprof_info.stdout"
+  failed_when: false
 
 # Install and configure XHProf.
 - name: Install XHProf using PECL.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,11 @@
 - include: setup-Debian.yml
   when: ansible_os_family == 'Debian'
 
+# Get XHProf info if installed.
+- name: Get XHProf info if installed.
+  command: "pecl info xhprof"
+  register: "xhprof_info"
+
 # Install and configure XHProf.
 - name: Install XHProf using PECL.
   command: "pecl install {{ item }}"
@@ -19,6 +24,7 @@
     # Manual channel installation required for certain PEAR versions.
     - "channel://pecl.php.net/xhprof-0.9.4"
     - xhprof
+  when: "not '0.9.4' in xhprof_info.stdout"
 
 - name: Copy XHProf INI into php.d folder.
   template:


### PR DESCRIPTION
Currently XHProf will try to be installed regardless of whether it is already installed, which is problematic when provisioning while offline.

This change simply gathers the local Pecl info for XHProf and then uses that as a conditional for the install task.
