### PR TITLE
Issue #9: Add variables for xhprof_lib and xhprof_html locations

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,4 +1,7 @@
 ---
+php_xhprof_lib_dir: /usr/share/php/xhprof_lib
+php_xhprof_html_dir: /usr/share/php/xhprof_html
+
 php_xhprof_config_filename: 20-xhprof.ini
 php_xhprof_config_dirs:
   - /etc/php5/apache2/conf.d

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,4 +1,7 @@
 ---
+php_xhprof_lib_dir: /usr/share/pear/xhprof_lib
+php_xhprof_html_dir: /usr/share/pear/xhprof_html
+
 php_xhprof_config_filename: xhprof.ini
 php_xhprof_config_dirs:
   - /etc/php.d


### PR DESCRIPTION
So it's actually not an install dir per se. Also, changing it wouldn't actually install it elsewhere unless we compile it ourselves.

Is this what you had in mind or is there some better way to do it? First I thought about registering it as a fact after running `pear config-get php_dir`, but then that wouldn't be available before the task had finished.
