### PR TITLE
Fix xhprof.output_dir not existing in systemd based PrivateTmp directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Where XHProf setup files will be downloaded and built.
 
 The URL from which XHProf will be downloaded. Note that this default is for the PHP 7-compatible version of XHProf. If you're using PHP 5.x, you should probably switch to the 'official' upstream source: `https://github.com/phacility/xhprof/archive/master.tar.gz`.
 
-    xhprof_output_dir: /var/tmp/xhprof
+    xhprof_output_dir: /tmp
 
 Directory where XHProf runs are stored.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,7 @@ xhprof_download_url: https://github.com/RustJason/xhprof/archive/php7.zip
 xhprof_download_folder_name: xhprof-php7
 # xhprof_download_folder_name: xhprof-master
 
-xhprof_output_dir: /var/tmp/xhprof
+xhprof_output_dir: /tmp
 
 php_xhprof_lib_dir: /usr/share/php/xhprof_lib
 php_xhprof_html_dir: /usr/share/php/xhprof_html


### PR DESCRIPTION
In case you decide to go with the https://github.com/geerlingguy/drupal-vm/pull/613#issuecomment-219024644 approach. We could also just set it for Drupal VM specifically but guessing others using this role might run into the same issue.

Could this [file task](https://github.com/geerlingguy/ansible-role-php-xhprof/blob/master/tasks/main.yml#L64) be an issue?
