### PR TITLE
Prevent repeated downloads

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,6 +26,7 @@
     src: "{{ xhprof_download_url }}"
     dest: "{{ workspace }}"
     copy: no
+    creates: "{{ workspace }}/{{ xhprof_download_folder_name }}"
 
 - name: Build XHProf.
   shell: >


### PR DESCRIPTION
The task `Download and untar XHProf` attempts to download the xhprof archive on every run.

This PR adds a `creates` argument to the task to prevent repeated downloads, like with the [download task in the Xdebug role](https://github.com/geerlingguy/ansible-role-php-xdebug/blob/master/tasks/main.yml#L27).  The task will run only if `"{{ workspace }}/{{ xhprof_download_folder_name }}"` doesn't already exist.